### PR TITLE
Fix compiler errors on Erlang >= 17

### DIFF
--- a/include/dhcp.hrl
+++ b/include/dhcp.hrl
@@ -1,3 +1,9 @@
+-ifdef(time_correction).
+-define(CURRENT_TIME, erlang:timestamp()).
+-else.
+-define(CURRENT_TIME, erlang:now()).
+-endif.
+
 -type message_type() ::
         discover | offer | request | decline |
         ack | nck | release | inform | force_renew.

--- a/include/dhcp.hrl
+++ b/include/dhcp.hrl
@@ -1,9 +1,3 @@
--ifdef(time_correction).
--define(CURRENT_TIME, erlang:timestamp()).
--else.
--define(CURRENT_TIME, erlang:now()).
--endif.
-
 -type message_type() ::
         discover | offer | request | decline |
         ack | nck | release | inform | force_renew.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,8 @@
 {lib_dirs, ["deps"]}.
-{erl_opts, [{parse_transform, lager_transform}, debug_info, warnings_as_errors]}.
+{erl_opts, [
+	{parse_transform, lager_transform}, debug_info, warnings_as_errors,
+	{platform_define, "(?=^[0-9]+)(?!^17$)", time_correction}
+]}.
 {deps,
  [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "1.2.2"}}},

--- a/src/dhcp_fsm.erl
+++ b/src/dhcp_fsm.erl
@@ -92,7 +92,7 @@ init([Socket, Handler]) ->
                          initial_timeout = Ti,
                          offer_timeout = To,
                          request_timeout = Tr,
-                         last = erlang:now()}, ?S(10)}.
+                         last = ?CURRENT_TIME}, ?S(10)}.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -156,10 +156,10 @@ offered(Pkg = #dhcp_package{xid = _XId, message_type = request},
             case delegate(request, Pkg, State) of
                 {ok, RPkg, State1} ->
                     Timeout = dhcp_package:get_option(ip_address_lease_time, dhcp_package:get_option(ip_address_lease_time, 3000, RPkg), Pkg),
-                    {next_state, bound, State#state{last=erlang:now(),
+                    {next_state, bound, State#state{last=?CURRENT_TIME,
                                                     handler_state = State1}, ?S(Timeout)};
                 {ok, State1} ->
-                    {next_state, offered, State#state{last=erlang:now(),
+                    {next_state, offered, State#state{last=?CURRENT_TIME,
                                                       handler_state = State1}, ?S(To)};
                 _ ->
                     {stop, normal, State}
@@ -198,7 +198,7 @@ bound(Pkg = #dhcp_package{xid = _XId, message_type = request},
             case delegate(request, Pkg, State) of
                 {ok, RPkg, State1} ->
                     Timeout = dhcp_package:get_option(ip_address_lease_time, RPkg),
-                    {next_state, bound, State#state{last=erlang:now(),
+                    {next_state, bound, State#state{last=?CURRENT_TIME,
                                                     handler_state = State1}, Timeout};
                 _ ->
                     {stop, normal, State}
@@ -335,12 +335,12 @@ delegate(F, Pkg, Opts, State = #state{handler = M}) ->
                     Dst = reply_addr(R),
                     {ok, Bin} = dhcp_package:encode(R),
                     gen_udp:send(State#state.socket, Dst, 68, Bin),
-                    {ok, R, State#state{handler_state = S1, last=erlang:now()}};
+                    {ok, R, State#state{handler_state = S1, last=?CURRENT_TIME}};
                 false ->
                     lager:error("[DHCP] invalid reply package for ~p:~p -> ~p", [M, F, R])
             end;
         {ok, S1} ->
-            {ok, State#state{handler_state = S1, last=erlang:now()}};
+            {ok, State#state{handler_state = S1, last=?CURRENT_TIME}};
         E ->
             E
     end.

--- a/src/dhcp_fsm.erl
+++ b/src/dhcp_fsm.erl
@@ -167,7 +167,7 @@ offered(Pkg = #dhcp_package{xid = _XId, message_type = request},
                 {ok, State1} ->
                     {next_state, offered, State#state{last=current_time(),
                                                       handler_state = State1},
-		                                      ?S(To)};
+                                                      ?S(To)};
                 _ ->
                     {stop, normal, State}
             end;

--- a/src/dhcp_fsm.erl
+++ b/src/dhcp_fsm.erl
@@ -92,7 +92,7 @@ init([Socket, Handler]) ->
                          initial_timeout = Ti,
                          offer_timeout = To,
                          request_timeout = Tr,
-                         last = ?CURRENT_TIME}, ?S(10)}.
+                         last = current_time()}, ?S(10)}.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -156,10 +156,10 @@ offered(Pkg = #dhcp_package{xid = _XId, message_type = request},
             case delegate(request, Pkg, State) of
                 {ok, RPkg, State1} ->
                     Timeout = dhcp_package:get_option(ip_address_lease_time, dhcp_package:get_option(ip_address_lease_time, 3000, RPkg), Pkg),
-                    {next_state, bound, State#state{last=?CURRENT_TIME,
+                    {next_state, bound, State#state{last=current_time(),
                                                     handler_state = State1}, ?S(Timeout)};
                 {ok, State1} ->
-                    {next_state, offered, State#state{last=?CURRENT_TIME,
+                    {next_state, offered, State#state{last=current_time(),
                                                       handler_state = State1}, ?S(To)};
                 _ ->
                     {stop, normal, State}
@@ -198,7 +198,7 @@ bound(Pkg = #dhcp_package{xid = _XId, message_type = request},
             case delegate(request, Pkg, State) of
                 {ok, RPkg, State1} ->
                     Timeout = dhcp_package:get_option(ip_address_lease_time, RPkg),
-                    {next_state, bound, State#state{last=?CURRENT_TIME,
+                    {next_state, bound, State#state{last=current_time(),
                                                     handler_state = State1}, Timeout};
                 _ ->
                     {stop, normal, State}
@@ -335,12 +335,12 @@ delegate(F, Pkg, Opts, State = #state{handler = M}) ->
                     Dst = reply_addr(R),
                     {ok, Bin} = dhcp_package:encode(R),
                     gen_udp:send(State#state.socket, Dst, 68, Bin),
-                    {ok, R, State#state{handler_state = S1, last=?CURRENT_TIME}};
+                    {ok, R, State#state{handler_state = S1, last=current_time()}};
                 false ->
                     lager:error("[DHCP] invalid reply package for ~p:~p -> ~p", [M, F, R])
             end;
         {ok, S1} ->
-            {ok, State#state{handler_state = S1, last=?CURRENT_TIME}};
+            {ok, State#state{handler_state = S1, last=current_time()}};
         E ->
             E
     end.
@@ -367,3 +367,9 @@ reply_addr(#dhcp_package{ciaddr = 0}) ->
 reply_addr(#dhcp_package{ciaddr = Addr}) ->
     <<A:8, B:8, C:8, D:8>> = <<Addr:32>>,
     {A, B, C, D}.
+
+-ifdef(time_correction).
+current_time() -> erlang:timestamp().
+-else.
+current_time() -> erlang:now().
+-endif.


### PR DESCRIPTION
Since Erlang 18, there is no `erlang:now()` BIF. This change makes the
code use the new `erlang:timestamp()` where appropriate.

Used advice from https://stackoverflow.com/a/34028460.